### PR TITLE
fixed UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1701: character maps to <undefined> error 

### DIFF
--- a/booknlp/common/sequence_layered_reader.py
+++ b/booknlp/common/sequence_layered_reader.py
@@ -153,7 +153,7 @@ def prepare_annotations_from_folder(folder, tagset, labeled=True):
 	sentences = []
 	for filename in os.listdir(folder):
 		print(filename)
-		annotations = read_annotations(os.path.join(folder,filename), tagset, labeled)
+		annotations = read_annotations(os.path.join(folder,filename).replace('\\', '/'), tagset, labeled)
 		sentences += annotations
 	print("num sentences: %s" % len(sentences))
 	return sentences

--- a/booknlp/english/english_booknlp.py
+++ b/booknlp/english/english_booknlp.py
@@ -336,7 +336,7 @@ class EnglishBookNLP:
 			start_time = time.time()
 			originalTime=start_time
 
-			with open(filename) as file:
+			with open(filename, encoding='utf-8') as file:
 				data=file.read()
 
 				if len(data) == 0:

--- a/booknlp/english/english_booknlp.py
+++ b/booknlp/english/english_booknlp.py
@@ -45,7 +45,7 @@ class EnglishBookNLP:
 				self.gender_cats=model_params["referential_gender_cats"]
 
 			home = str(Path.home())
-			modelPath=os.path.join(home, "booknlp_models")
+			modelPath=os.path.join(home, "booknlp_models").replace('\\', '/')
 			if "model_path"  in model_params:			
 				modelPath=model_params["model_path"]
 
@@ -57,17 +57,17 @@ class EnglishBookNLP:
 				corefName="coref_google_bert_uncased_L-12_H-768_A-12-v1.0.model"
 				quoteAttribName="speaker_google_bert_uncased_L-12_H-768_A-12-v1.0.1.model"
 
-				self.entityPath=os.path.join(modelPath, entityName)
+				self.entityPath=os.path.join(modelPath, entityName).replace('\\', '/')
 				if not Path(self.entityPath).is_file():
 					print("downloading %s" % entityName)
 					urllib.request.urlretrieve("http://ischool.berkeley.edu/~dbamman/booknlp_models/%s" % entityName, self.entityPath)
 
-				self.coref_model=os.path.join(modelPath, corefName)
+				self.coref_model=os.path.join(modelPath, corefName).replace('\\', '/')
 				if not Path(self.coref_model).is_file():
 					print("downloading %s" % corefName)
 					urllib.request.urlretrieve("http://ischool.berkeley.edu/~dbamman/booknlp_models/%s" % corefName, self.coref_model)
 
-				self.quoteAttribModel=os.path.join(modelPath, quoteAttribName)
+				self.quoteAttribModel=os.path.join(modelPath, quoteAttribName).replace('\\', '/')
 				if not Path(self.quoteAttribModel).is_file():
 					print("downloading %s" % quoteAttribName)
 					urllib.request.urlretrieve("http://ischool.berkeley.edu/~dbamman/booknlp_models/%s" % quoteAttribName, self.quoteAttribModel)
@@ -78,17 +78,17 @@ class EnglishBookNLP:
 				corefName="coref_google_bert_uncased_L-2_H-256_A-4-v1.0.model"
 				quoteAttribName="speaker_google_bert_uncased_L-8_H-256_A-4-v1.0.1.model"
 
-				self.entityPath=os.path.join(modelPath, entityName)
+				self.entityPath=os.path.join(modelPath, entityName).replace('\\', '/')
 				if not Path(self.entityPath).is_file():
 					print("downloading %s" % entityName)
 					urllib.request.urlretrieve("http://ischool.berkeley.edu/~dbamman/booknlp_models/%s" % entityName, self.entityPath)
 
-				self.coref_model=os.path.join(modelPath, corefName)
+				self.coref_model=os.path.join(modelPath, corefName).replace('\\', '/')
 				if not Path(self.coref_model).is_file():
 					print("downloading %s" % corefName)
 					urllib.request.urlretrieve("http://ischool.berkeley.edu/~dbamman/booknlp_models/%s" % corefName, self.coref_model)
 
-				self.quoteAttribModel=os.path.join(modelPath, quoteAttribName)
+				self.quoteAttribModel=os.path.join(modelPath, quoteAttribName).replace('\\', '/')
 				if not Path(self.quoteAttribModel).is_file():
 					print("downloading %s" % quoteAttribName)
 					urllib.request.urlretrieve("http://ischool.berkeley.edu/~dbamman/booknlp_models/%s" % quoteAttribName, self.quoteAttribModel)
@@ -603,5 +603,3 @@ class EnglishBookNLP:
 
 				print("--- TOTAL (excl. startup): %.3f seconds ---, %s words" % (time.time() - originalTime, len(tokens)))
 				return time.time() - originalTime
-
-

--- a/booknlp/english/gender_inference_model_1.py
+++ b/booknlp/english/gender_inference_model_1.py
@@ -163,7 +163,7 @@ class GenderEM:
 
 	def read_hyperparams(self, filename):
 		self.hyperparameters={}
-		with open(filename) as file:
+		with open(filename, 'r', encoding='utf-8') as file:
 			header=file.readline().rstrip()
 			gender_mapping={}
 			for idx, val in enumerate(header.split("\t")[2:]):
@@ -576,8 +576,8 @@ if __name__ == "__main__":
 	ent_files=[]
 	tok_files=[]
 	for idd in (onlyfiles[:num]):
-		entitiyFile=os.path.join(top, idd, "%s.entities" % idd)
-		tokensFile=os.path.join(top, idd, "%s.tokens" % idd)
+		entitiyFile=os.path.join(top, idd, "%s.entities" % idd).replace('\\', '/')
+		tokensFile=os.path.join(top, idd, "%s.tokens" % idd).replace('\\', '/')
 		if isfile(entityFile) and isfile(tokensFile):
 			ent_files.append(entityFile)
 			tok_files.append(tokensFile)
@@ -585,4 +585,3 @@ if __name__ == "__main__":
 	genders=[ ["he", "him", "his"], ["she", "her"], ["they", "them", "their"] ] 
 	genderEM=GenderEM(outfile=outfile, entityFiles=ent_files, tokenFiles=tok_files, hyperparameterFile=hyperparams, genders=genders)
 	genderEM.tagFromFile(ent_files, tok_files)
-


### PR DESCRIPTION

# Issue Resolution Documentation

## Issue Description

When running the script `test_booknlp.py`, I encountered a `UnicodeDecodeError`. This error occurred while the script was processing with the following configuration and outputs:

```plaintext
PS C:\Users\super\Pictures> python .\test_booknlp.py
using device cpu
{'pipeline': 'entity,quote,supersense,event,coref', 'model': 'big'}
--- startup: 26.651 seconds ---
--- spacy: 0.031 seconds ---
--- entities: 0.562 seconds ---
--- quotes: 0.000 seconds ---
--- attribution: 0.000 seconds ---
--- name coref: 0.000 seconds ---
Traceback (most recent call last):
  File "C:\Users\super\Pictures\test_booknlp.py", line 19, in <module>
    booknlp.process(input_file, output_directory, book_id)
  File "C:\Users\super\AppData\Local\Programs\Python\Python310\lib\site-packages\booknlp\booknlp.py", line 17, in process
    self.booknlp.process(inputFile, outputFolder, idd)
  File "C:\Users\super\AppData\Local\Programs\Python\Python310\lib\site-packages\booknlp\english\english_booknlp.py", line 426, in process
    genderEM=GenderEM(tokens=tokens, entities=entities, refs=refs, genders=self.gender_cats, hyperparameterFile=self.gender_hyperparameterFile)
  File "C:\Users\super\AppData\Local\Programs\Python\Python310\lib\site-packages\booknlp\english\gender_inference_model_1.py", line 71, in __init__
    self.read_hyperparams(hyperparameterFile)
  File "C:\Users\super\AppData\Local\Programs\Python\Python310\lib\site-packages\booknlp\english\gender_inference_model_1.py", line 167, in read_hyperparams
    header=file.readline().rstrip()
  File "C:\Users\super\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1701: character maps to <undefined>
```

## Resolution Steps

The issue was resolved by specifying the correct encoding when opening a file within the `gender_inference_model_1.py`. This was necessary due to the presence of characters in the file that were not compatible with the default `cp1252` encoding used by Python on Windows.

### Modified Code

The problematic line in the script:

```python
with open(filename) as file:
```

was replaced with:

```python
with open(filename, 'r', encoding='utf-8') as file:
```

This change ensures that the file is read with UTF-8 encoding, which can handle a broader range of characters, thus preventing the `UnicodeDecodeError`.
